### PR TITLE
Moving the HTTPS redirection config line to development only

### DIFF
--- a/FlashCard/Program.cs
+++ b/FlashCard/Program.cs
@@ -89,9 +89,8 @@ namespace FlashCard
             {
                 app.UseSwagger();
                 app.UseSwaggerUI();
+                app.UseHttpsRedirection();
             }
-
-            app.UseHttpsRedirection();
 
             app.UseCors(CORS_POLICY_NAME);
 


### PR DESCRIPTION
This configuration is not working with Docker/Azure, so I'm disabling it.